### PR TITLE
RMET-547 Firebase Crashlytics Plugin - Fix configurations hook

### DIFF
--- a/hooks/configurations/unzipAndCopyConfigurations.js
+++ b/hooks/configurations/unzipAndCopyConfigurations.js
@@ -5,6 +5,8 @@ var AdmZip = require("adm-zip");
 
 var utils = require("./utilities");
 
+var utilsApp = require("../utilities");
+
 var constants = {
   googleServices: "google-services"
 };
@@ -53,13 +55,31 @@ module.exports = function(context) {
   var sourceFilePath = path.join(targetPath, fileName);
   var destFilePath = path.join(context.opts.plugin.dir, fileName);
 
-  utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
+  var androidPath =  "platforms/android/app";
+  var iOSPath = "platforms/ios/" + utilsApp.getAppName(context) + "/Resources";
+
+  var completeFilePath;
+
+  var isAndroid = platform.localeCompare("android");
+  var isIOS = platform.localeCompare("ios");
+
+  if(isAndroid == 0){ //android code
+    completeFilePath = path.join(context.opts.projectRoot, androidPath);
+  }
+  else if(isIOS == 0){ //iOS code
+    completeFilePath = path.join(context.opts.projectRoot, iOSPath);
+  }
+
+  if(!utils.checkIfFolderExists(destFilePath)){
+    utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
+  }
 
   if (cordovaAbove7) {
-    var destPath = path.join(context.opts.projectRoot, "platforms", platform, "app");
-    if (utils.checkIfFolderExists(destPath)) {
-      var destFilePath = path.join(destPath, fileName);
-      utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
+    if (utils.checkIfFolderExists(completeFilePath)) {
+      var destFilePath = path.join(completeFilePath, fileName);
+      if(!utils.checkIfFolderExists(destFilePath)){
+        utils.copyFromSourceToDestPath(defer, sourceFilePath, destFilePath);
+      }
     }
   }
       

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-ios" version=">=5.1.1"/>
     </engines>
 
-    <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#fix/RMET-547/configurations-hook"/>
+    <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#outsystems"/>
 
     <js-module src="www/FirebaseCrash.js" name="FirebaseCrash">
         <merges target="cordova.plugins.firebase.crashlytics" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-ios" version=">=5.1.1"/>
     </engines>
 
-    <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#outsystems"/>
+    <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#fix/RMET-547/configurations-hook"/>
 
     <js-module src="www/FirebaseCrash.js" name="FirebaseCrash">
         <merges target="cordova.plugins.firebase.crashlytics" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fixes the way we copy the firebase configuration files, because the iOS file path was wrong. Also we need to check if the file already exists before copying.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

The hook did not use the correct file path for iOS and did not check if the files already exist before copying.

References: https://outsystemsrd.atlassian.net/browse/RMET-547

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

MABS builds all working.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
