### PR TITLE
RMET-580 Firebase Crashlytics Plugin - Fix Android Google Services build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
-
-
 ## 2021-04-08
+- Chore: raise version 3.0.0-OS
 - Fix: Fixed Android MABS builds for Firebase Crashlytics being used with OneSignal (https://outsystemsrd.atlassian.net/browse/RMET-580)
 ## 2021-03-29
 - Fix: Fixed hook unzipAndCopyConfigurations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+
+## 2021-04-08
+- Fix: Fixed Android MABS builds for Firebase Crashlytics being used with OneSignal (https://outsystemsrd.atlassian.net/browse/RMET-580)
 ## 2021-03-29
 - Fix: Fixed hook unzipAndCopyConfigurations
-
 ## 2021-03-19
 - Feature: Added method to crash app for both in Android and iOS. (https://outsystemsrd.atlassian.net/browse/RMET-434)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-crash",
-  "version": "3.0.0",
+  "version": "3.0.0-OS",
   "description": "Cordova plugin for Firebase Crashlytics",
   "cordova": {
     "id": "cordova-plugin-firebase-crash",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-crash"
-      version="3.0.0">
+      version="3.0.0-OS">
 
     <name>cordova-plugin-firebase-crash</name>
     <description>Cordova plugin for Firebase Crashlytics</description>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -33,5 +33,6 @@ ext.postBuildExtras = {
         // apply plugin: 'com.google.gms.google-services'
         // class must be used instead of id(string) to be able to apply plugin from non-root gradle file
         apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+        googleServices.disableVersionCheck = true
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Used flag in build.gradle to disable version checking for google services.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

We were having a build error for Android when building an app with Firebase Crashlytics and OneSignal because the two plugins have different versions of google services. So we disabled version checking for google-services and the build works. The plugins are also working fine. 

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

All MABS builds working and plugins working as well.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
