### PR TITLE
RMET-732 Updated Crashlytics plugin version on Android and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2021-08-24
+- Updated Firebase plugin versions to 8.6.0 on iOS and 18.2.+ on Android [RMET-732](https://outsystemsrd.atlassian.net/browse/RMET-732)
+
 ## [3.0.0-OS1]
 
 ## 2021-07-22

--- a/plugin.xml
+++ b/plugin.xml
@@ -51,12 +51,16 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <header-file src="src/ios/FirebaseCrashPlugin.h" />
         <source-file src="src/ios/FirebaseCrashPlugin.m" />
 
-        <framework src="Firebase/Crashlytics" type="podspec" spec="~> 8.6.0"/>
-
+        <podspec>
+            <pods>
+                <pod name="Firebase/Crashlytics" spec="~> 8.6.0" />
+            </pods>
+        </podspec>
+        
     </platform>
 
     <platform name="android">
-        <preference name="ANDROID_FIREBASE_CRASHLYTICS_VERSION" default="17.3.+"/>
+        <preference name="ANDROID_FIREBASE_CRASHLYTICS_VERSION" default="18.2.+"/>
 
         <config-file parent="/*" target="res/xml/config.xml">
             <feature name="FirebaseCrash">

--- a/plugin.xml
+++ b/plugin.xml
@@ -52,8 +52,11 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <source-file src="src/ios/FirebaseCrashPlugin.m" />
 
         <podspec>
+            <config>
+                <source url="https://cdn.cocoapods.org/"/>
+            </config>
             <pods>
-                <pod name="Firebase/Crashlytics" spec="~> 8.6.0" />
+                <pod name="Firebase/Crashlytics" spec="$IOS_FIREBASE_CRASHLYTICS_VERSION" />
             </pods>
         </podspec>
         

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-ios" version=">=5.1.1"/>
     </engines>
 
-    <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#fix/RMET-732/added-app-tracking-transparency"/>
+    <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#outsystems"/>
 
     <js-module src="www/FirebaseCrash.js" name="FirebaseCrash">
         <merges target="cordova.plugins.firebase.crashlytics" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-ios" version=">=5.1.1"/>
     </engines>
 
-    <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#5.0.0-OS1"/>
+    <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#fix/RMET-732/added-app-tracking-transparency"/>
 
     <js-module src="www/FirebaseCrash.js" name="FirebaseCrash">
         <merges target="cordova.plugins.firebase.crashlytics" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -28,7 +28,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <hook type="before_plugin_install" src="hooks/configurations/unzipAndCopyConfigurations.js" />
 
     <platform name="ios">
-        <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="~> 7.0.0"/>
+        <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="~> 8.6.0"/>
 
         <hook type="after_plugin_install" src="hooks/ios/after_plugin_install.js" />
         <hook type="before_plugin_uninstall" src="hooks/ios/before_plugin_uninstall.js" />
@@ -51,7 +51,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <header-file src="src/ios/FirebaseCrashPlugin.h" />
         <source-file src="src/ios/FirebaseCrashPlugin.m" />
 
-        <framework src="Firebase/Crashlytics" type="podspec" spec="~> 7.0.0"/>
+        <framework src="Firebase/Crashlytics" type="podspec" spec="~> 8.6.0"/>
 
     </platform>
 


### PR DESCRIPTION
## Description
Updated Firebase library version to 8.6.0 on iOS, and 18.2.+ on Android

## Context
The original issue was extended to upgrade Firebase/Crashlytics version. Because of this, we also needed to update the remaining Firebase plugins.
https://outsystemsrd.atlassian.net/browse/RMET-732

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [X] iOS
- [ ] JavaScript

## Tests
Tested on MABS 7.1.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [X] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
