### PR TITLE
RMET-1691 Firebase Crashlytics - Use try catch to prevent crash and then only use object if not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2022-07-1
+- Avoid crash with try catch [RMET-1538](https://outsystemsrd.atlassian.net/browse/RMET-1691)
+
 ## [3.0.0-OS5]
 ## 2022-05-16
 - Updated dependency to analytics plugin [RMET-1538](https://outsystemsrd.atlassian.net/browse/RMET-1538)

--- a/src/android/FirebaseCrashPlugin.java
+++ b/src/android/FirebaseCrashPlugin.java
@@ -21,7 +21,12 @@ public class FirebaseCrashPlugin extends ReflectiveCordovaPlugin {
     protected void pluginInitialize() {
         Log.d(TAG, "Starting Firebase Crashlytics plugin");
 
-        firebaseCrashlytics = FirebaseCrashlytics.getInstance();
+        try{
+            firebaseCrashlytics = FirebaseCrashlytics.getInstance();
+        }
+        catch (Exception e){
+            Log.e("Firebase Crashlytics Plugin", e.getMessage());
+        }
     }
 
     @CordovaMethod(ExecutionThread.WORKER)
@@ -36,30 +41,34 @@ public class FirebaseCrashPlugin extends ReflectiveCordovaPlugin {
 
     @CordovaMethod(ExecutionThread.WORKER)
     private void log(String message, CallbackContext callbackContext) {
-        firebaseCrashlytics.log(message);
-
-        callbackContext.success();
+        if(firebaseCrashlytics != null){
+            firebaseCrashlytics.log(message);
+            callbackContext.success();
+        }
     }
 
     @CordovaMethod(ExecutionThread.UI)
     private void logError(String message, CallbackContext callbackContext) {
-        firebaseCrashlytics.recordException(new Exception(message));
-
-        callbackContext.success();
+        if(firebaseCrashlytics != null){
+            firebaseCrashlytics.recordException(new Exception(message));
+            callbackContext.success();
+        }
     }
 
     @CordovaMethod(ExecutionThread.UI)
     private void setUserId(String userId, CallbackContext callbackContext) {
-        firebaseCrashlytics.setUserId(userId);
-
-        callbackContext.success();
+        if(firebaseCrashlytics != null){
+            firebaseCrashlytics.setUserId(userId);
+            callbackContext.success();
+        }
     }
 
     @CordovaMethod
     private void setEnabled(boolean enabled, CallbackContext callbackContext) {
-        firebaseCrashlytics.setCrashlyticsCollectionEnabled(enabled);
-
-        callbackContext.success();
+        if(firebaseCrashlytics != null){
+            firebaseCrashlytics.setCrashlyticsCollectionEnabled(enabled);
+            callbackContext.success();
+        }
     }
 
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
A support case reported that the app was crashing because of the `FirebaseCrashlytics.getInstance()` call.
Now we use a try catch clause to catch the exception, and only use the FirebaseCrashlytics object if it is not null.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1691

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS builds.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
