### PR TITLE
RMET-1717 Firebase Crashlytics - Remove dependency to Analytics plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 2022-07-14
+- Remove dependency to Firebase Analytics  [RMET-1715](https://outsystemsrd.atlassian.net/browse/RMET-1717)
+
 ## [3.0.0-OS6]
 
 ## 2022-07-12

--- a/plugin.xml
+++ b/plugin.xml
@@ -84,6 +84,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <source-file src="src/android/FirebaseCrashPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase/" />
 
+        <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
+
         <framework src="com.google.firebase:firebase-crashlytics:$ANDROID_FIREBASE_CRASHLYTICS_VERSION" />
         <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,8 +16,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-ios" version=">=5.1.1"/>
     </engines>
 
-    <!--<dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#5.0.0-OS6"/>-->
-
     <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#1.0.1"/>
 
     <js-module src="www/FirebaseCrash.js" name="FirebaseCrash">
@@ -25,9 +23,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </js-module>
 
     <preference name="FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" default="true" />
-
-    <!--<hook type="before_plugin_install" src="hooks/configurations/installDependencies.js" />
-    <hook type="before_plugin_install" src="hooks/configurations/unzipAndCopyConfigurations.js" />-->
 
     <platform name="ios">
         <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="~> 8.6.0"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,14 +18,16 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
     <!--<dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#5.0.0-OS6"/>-->
 
+    <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#1.0.1"/>
+
     <js-module src="www/FirebaseCrash.js" name="FirebaseCrash">
         <merges target="cordova.plugins.firebase.crashlytics" />
     </js-module>
 
     <preference name="FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" default="true" />
 
-    <hook type="before_plugin_install" src="hooks/configurations/installDependencies.js" />
-    <hook type="before_plugin_install" src="hooks/configurations/unzipAndCopyConfigurations.js" />
+    <!--<hook type="before_plugin_install" src="hooks/configurations/installDependencies.js" />
+    <hook type="before_plugin_install" src="hooks/configurations/unzipAndCopyConfigurations.js" />-->
 
     <platform name="ios">
         <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="~> 8.6.0"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,7 +16,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-ios" version=">=5.1.1"/>
     </engines>
 
-    <dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#5.0.0-OS6"/>
+    <!--<dependency id="cordova-plugin-firebase-analytics" url="https://github.com/OutSystems/cordova-plugin-firebase-analytics.git#5.0.0-OS6"/>-->
 
     <js-module src="www/FirebaseCrash.js" name="FirebaseCrash">
         <merges target="cordova.plugins.firebase.crashlytics" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR removes the dependency that the Crashlytics plugin had on the Analytics plugin, by instead adding a dependency to the firebase-core plugin.
- This not only makes the Firebase plugin family easier to maintain, but it also makes it easier for our customers to use the Firebase plugins.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-1717

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS 8.1 builds and tested Firebase Crashlytics plugin as the only plugin in an app as well as in the Firebase Sample App with all the other Firebase plugins. Tests were done for Android and iOS.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
