### PR TITLE
RNMT-2546 - Update dependency fixed version

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -81,7 +81,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <source-file src="src/android/FirebaseCrashPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase/" />
 
-        <dependency id="cordova-support-android-plugin" version="~>1.0.0"/>
+        <dependency id="cordova-support-android-plugin" version=">=1.0.0"/>
 
         <framework src="com.google.firebase:firebase-crashlytics:$ANDROID_FIREBASE_CRASHLYTICS_VERSION" />
         <framework src="src/android/build.gradle" custom="true" type="gradleReference" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -81,7 +81,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <source-file src="src/android/FirebaseCrashPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase/" />
 
-        <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
+        <dependency id="cordova-support-android-plugin" version="~>1.0.0"/>
 
         <framework src="com.google.firebase:firebase-crashlytics:$ANDROID_FIREBASE_CRASHLYTICS_VERSION" />
         <framework src="src/android/build.gradle" custom="true" type="gradleReference" />


### PR DESCRIPTION
because the version of cordova-support-android-plugin is 2.0.4 now, so that lead to can't gen application.

## Description
I changed the version of cordova-support-android-plugin to ~>1.0.0 to adapt new version of that plugin

## Context
I am facing issue when generate the mobile with the Cordova plugin cordova-plugin-firebase-crash, the issue is: Failed to install 'cordova-plugin-firebase-crash': CordovaError: Version of installed plugin: "cordova-support-android-plugin@2.0.4" does not satisfy dependency plugin requirement "cordova-support-android-plugin@~1.0.0". Try --force to use installed plugin as dependency. So that I think change the version of cordova-support-android-plugin to ~>1.0.0 can fix my issue.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x ] Pull request title follows the format `RNMT-XXXX <title>`
- [ x] Code follows code style of this project
- [x ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
