### PR TITLE
RMET-3274 ::: iOS ::: Update 3rd Party that Adds Privacy Manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+
+### 2024-03-21
+- Chore: Update `FirebaseCrashlytics` iOS pod to version `10.23.0`. This includes the Privacy Manifest (https://outsystemsrd.atlassian.net/browse/RMET-3274).
+
 ### 2024-01-30
-- Chore: Update Firebase/Crashlytics pod to version 8.15.0. (https://outsystemsrd.atlassian.net/browse/RMET-3143)
+- Chore: Update `Firebase/Crashlytics` iOS pod to version `8.15.0` (https://outsystemsrd.atlassian.net/browse/RMET-3143).
 
 ## [3.0.0-OS9]
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,7 +25,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <preference name="FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" default="true" />
 
     <platform name="ios">
-        <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="8.15.0"/>
+        <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="10.23.0"/>
 
         <hook type="after_plugin_install" src="hooks/ios/after_plugin_install.js" />
         <hook type="before_plugin_uninstall" src="hooks/ios/before_plugin_uninstall.js" />
@@ -52,8 +52,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <config>
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
-            <pods>
-                <pod name="Firebase/Crashlytics" spec="$IOS_FIREBASE_CRASHLYTICS_VERSION" />
+            <pods use-frameworks="true">
+                <pod name="FirebaseCrashlytics" spec="$IOS_FIREBASE_CRASHLYTICS_VERSION" />
             </pods>
         </podspec>
         

--- a/src/ios/FirebaseCrashPlugin.m
+++ b/src/ios/FirebaseCrashPlugin.m
@@ -1,6 +1,7 @@
 #import "FirebaseCrashPlugin.h"
 
-@import Firebase;
+@import FirebaseCore;
+@import FirebaseCrashlytics;
 
 @implementation FirebaseCrashPlugin
 


### PR DESCRIPTION
## Description
- Update 3rd party SDK version to `10.23.0`.
- Enable the `use_frameworks` flag for CocoaPods.
- Fix import errors.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-3274

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
Manual testing was performed and all were successful.

## Firebase Sample App Privacy Report
[Firebase Sample App-PrivacyReport.pdf](https://github.com/OutSystems/cordova-plugin-firebase-crash/files/14699117/Firebase.Sample.App-PrivacyReport.pdf)

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
