### PR TITLE
RMET-3644 - Add Capacitor compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 3.0.0-OS12
+
+### 2025-05-05
+
+- Feat: Support for Capacitor, including build actions (https://outsystemsrd.atlassian.net/browse/RMET-3644).
+- Chore: Remove depenency on `cordova-outsystems-firebase-core` (https://outsystemsrd.atlassian.net/browse/RMET-3644).
+- Chore: Android | Removes dependency to `cordova-support-android-plugin` (https://outsystemsrd.atlassian.net/browse/RMET-36434.
+
 ## 3.0.0-OS11
 
 - Feat: Android | Update dependency to Firebase Crashlytics Android library (https://outsystemsrd.atlassian.net/browse/RMET-3608).

--- a/build-actions/README.md
+++ b/build-actions/README.md
@@ -1,0 +1,31 @@
+
+# Build Actions
+
+This folder contains a .yaml file for configuring build actions to use in a plugin on ODC with Capacitor. The purpose of these build actions is to provide the same functionality as cordova hooks, but on a Capacitor shell.
+
+## Contents
+
+The file [updateCrashlyticsConfig.yaml](./updateCrashlyticsConfig.yaml) contains three build actions:
+
+1. Android specific. Adds the `firebase_performance_collection_enabled` meta-data entry - according to the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` parameter - to the app's `AndroidManifest.xml`. With it you can enable/disable crashlytics in the Android app.
+2. iOS specific. Set `FirebaseCrashlyticsCollectionEnabled` - according to the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` parameter - in the app's Info.plist file. With it you can enable/disable crashlytics in the iOS app.
+3. iOS specific. Adds a build phase for XCode to upload files to Firebase, to help with getting more readable crash reports.
+
+
+## Outsystems' Usage
+
+1. Copy the build action yaml file (which can contain multiple build actions inside) into the ODC Plugin, placing them in "Data" -> "Resources" and set "Deploy Action" to "Deploy to Target Directory", with target directory empty.
+2. Update the Plugin's Extensibility configuration to use the build action.
+
+```json
+{
+    "buildConfigurations": {
+        "buildAction": {
+            "config": $resources.buildActionFileName.yaml,
+            "parameters": {
+                // parameters go here; if there are no parameters then the block can be ommited
+            }
+        }
+    }
+}
+```

--- a/build-actions/README.md
+++ b/build-actions/README.md
@@ -5,11 +5,12 @@ This folder contains a .yaml file for configuring build actions to use in a plug
 
 ## Contents
 
-The file [updateCrashlyticsConfig.yaml](./updateCrashlyticsConfig.yaml) contains three build actions:
+The file [updateCrashlyticsConfig.yaml](./updateCrashlyticsConfig.yaml) contains four build actions:
 
 1. Android specific. Adds the `firebase_performance_collection_enabled` meta-data entry - according to the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` parameter - to the app's `AndroidManifest.xml`. With it you can enable/disable crashlytics in the Android app.
-2. iOS specific. Set `FirebaseCrashlyticsCollectionEnabled` - according to the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` parameter - in the app's Info.plist file. With it you can enable/disable crashlytics in the iOS app.
-3. iOS specific. Adds a build phase for XCode to upload files to Firebase, to help with getting more readable crash reports.
+2. Android specific. Apply the Firebase Android Gradle Plugin in the application's `build.gradle` file. Required because plugins Android code is added as separate library modules in Capacitor - and you cannot apply Crashlytics AGP to a library module.
+3. iOS specific. Set `FirebaseCrashlyticsCollectionEnabled` - according to the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` parameter - in the app's Info.plist file. With it you can enable/disable crashlytics in the iOS app.
+4. iOS specific. Adds a build phase for XCode to upload files to Firebase, to help with getting more readable crash reports.
 
 
 ## Outsystems' Usage

--- a/build-actions/README.md
+++ b/build-actions/README.md
@@ -5,12 +5,11 @@ This folder contains a .yaml file for configuring build actions to use in a plug
 
 ## Contents
 
-The file [updateCrashlyticsConfig.yaml](./updateCrashlyticsConfig.yaml) contains four build actions:
+The file [updateCrashlyticsConfig.yaml](./updateCrashlyticsConfig.yaml) contains three build actions:
 
 1. Android specific. Adds the `firebase_performance_collection_enabled` meta-data entry - according to the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` parameter - to the app's `AndroidManifest.xml`. With it you can enable/disable crashlytics in the Android app.
-2. Android specific. Apply the Firebase Android Gradle Plugin in the application's `build.gradle` file. Required because plugins Android code is added as separate library modules in Capacitor - and you cannot apply Crashlytics AGP to a library module.
-3. iOS specific. Set `FirebaseCrashlyticsCollectionEnabled` - according to the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` parameter - in the app's Info.plist file. With it you can enable/disable crashlytics in the iOS app.
-4. iOS specific. Adds a build phase for XCode to upload files to Firebase, to help with getting more readable crash reports.
+2. iOS specific. Set `FirebaseCrashlyticsCollectionEnabled` - according to the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` parameter - in the app's Info.plist file. With it you can enable/disable crashlytics in the iOS app.
+3. iOS specific. Adds a build phase for XCode to upload files to Firebase, to help with getting more readable crash reports.
 
 
 ## Outsystems' Usage

--- a/build-actions/updateCrashlyticsConfig.yaml
+++ b/build-actions/updateCrashlyticsConfig.yaml
@@ -10,21 +10,6 @@ platforms:
         target: manifest/application
         inject: |
           <meta-data android:name="firebase_performance_collection_enabled" android:value="$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" />
-    gradle:
-      - file: app/build.gradle
-        target:
-        insert: |
-          apply plugin: com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPlugin
-          android {
-              buildTypes {
-                  debug {
-                      // do not upload debug versions to crashlytics
-                      firebaseCrashlytics {
-                          mappingFileUploadEnabled false
-                      }
-                  }
-              }
-          }
   ios:
     plist:
       - replace: false

--- a/build-actions/updateCrashlyticsConfig.yaml
+++ b/build-actions/updateCrashlyticsConfig.yaml
@@ -1,0 +1,24 @@
+variables:
+  FIREBASE_CRASHLYTICS_COLLECTION_ENABLED:
+    default: true
+    type: boolean
+
+platforms:
+  android:
+    manifest:
+      - file: AndroidManifest.xml
+        target: manifest/application
+        inject: |
+          <meta-data android:name="firebase_performance_collection_enabled" android:value="$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" />
+  ios:
+    plist:
+      - replace: false
+        entries:
+          - FirebaseCrashlyticsCollectionEnabled: "$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED"
+    buildPhases:
+      - comment: Crashlytics
+        shellPath: "/bin/sh"
+        shellScript: "\"${PODS_ROOT}/FirebaseCrashlytics/run\""
+        inputPaths: ["\"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)\""]
+    
+  

--- a/build-actions/updateCrashlyticsConfig.yaml
+++ b/build-actions/updateCrashlyticsConfig.yaml
@@ -10,6 +10,21 @@ platforms:
         target: manifest/application
         inject: |
           <meta-data android:name="firebase_performance_collection_enabled" android:value="$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" />
+    gradle:
+      - file: app/build.gradle
+        target:
+        insert: |
+          apply plugin: com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPlugin
+          android {
+              buildTypes {
+                  debug {
+                      // do not upload debug versions to crashlytics
+                      firebaseCrashlytics {
+                          mappingFileUploadEnabled false
+                      }
+                  }
+              }
+          }
   ios:
     plist:
       - replace: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-crash",
-  "version": "3.0.0-OS11",
+  "version": "3.0.0-OS12",
   "description": "Cordova plugin for Firebase Crashlytics",
   "cordova": {
     "id": "cordova-plugin-firebase-crash",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-crash"
-      version="3.0.0-OS11">
+      version="3.0.0-OS12">
 
     <name>cordova-plugin-firebase-crash</name>
     <description>Cordova plugin for Firebase Crashlytics</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -72,9 +72,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <uses-permission android:name="android.permission.INTERNET" />
   		</edit-config>
 
-        <edit-config target="AndroidManifest.xml" parent="application">
+        <config-file target="AndroidManifest.xml" parent="/manifest/application">
             <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" />
-        </edit-config>
+        </config-file>
 
         <source-file src="src/android/FirebaseCrashPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase/" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -70,13 +70,13 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </feature>
         </config-file>
 
-        <config-file target="AndroidManifest.xml" parent="/*">
+        <edit-config target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.INTERNET" />
-  		</config-file>
+  		</edit-config>
 
-        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+        <edit-config target="AndroidManifest.xml" parent="application">
             <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" />
-        </config-file>
+        </edit-config>
 
         <source-file src="src/android/FirebaseCrashPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase/" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -78,8 +78,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <source-file src="src/android/FirebaseCrashPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase/" />
 
-        <dependency id="cordova-support-android-plugin" version="~1.0.0"/>
-
         <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     </platform>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -16,8 +16,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <engine name="cordova-ios" version=">=5.1.1"/>
     </engines>
 
-    <dependency id="cordova-outsystems-firebase-core" url="https://github.com/OutSystems/cordova-outsystems-firebase-core.git#2.0.0"/>
-
     <js-module src="www/FirebaseCrash.js" name="FirebaseCrash">
         <merges target="cordova.plugins.firebase.crashlytics" />
     </js-module>

--- a/src/android/.gitignore
+++ b/src/android/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+build/
+.idea/

--- a/src/android/FirebaseCrashPlugin.java
+++ b/src/android/FirebaseCrashPlugin.java
@@ -56,38 +56,32 @@ public class FirebaseCrashPlugin extends CordovaPlugin {
     }
 
     private void forceCrash() {
-        cordova.getThreadPool().execute(() -> {
+        new Thread(() -> {
             throw new RuntimeException("MyCrash");
-        });
+        }).start();
     }
 
     private void log(String message, CallbackContext callbackContext) {
-        cordova.getThreadPool().execute(() -> {
-            if(firebaseCrashlytics != null){
-                firebaseCrashlytics.log(message);
-                callbackContext.success();
-            }
-        });
+        if(firebaseCrashlytics != null){
+            firebaseCrashlytics.log(message);
+            callbackContext.success();
+        }
     }
 
     private void logError(String message, CallbackContext callbackContext) {
-        cordova.getActivity().runOnUiThread(() -> {
-            if(firebaseCrashlytics != null){
-                Exception error = new Exception(message);
-                Log.d(TAG, "Logging non-fatal error to crashlytics", error);
-                firebaseCrashlytics.recordException(error);
-                callbackContext.success();
-            }
-        });
+        if(firebaseCrashlytics != null){
+            Exception error = new Exception(message);
+            Log.d(TAG, "Logging non-fatal error to crashlytics", error);
+            firebaseCrashlytics.recordException(error);
+            callbackContext.success();
+        }
     }
 
     private void setUserId(String userId, CallbackContext callbackContext) {
-        cordova.getActivity().runOnUiThread(() -> {
-            if(firebaseCrashlytics != null){
-                firebaseCrashlytics.setUserId(userId);
-                callbackContext.success();
-            }
-        });
+        if(firebaseCrashlytics != null){
+            firebaseCrashlytics.setUserId(userId);
+            callbackContext.success();
+        }
     }
 
     private void setEnabled(boolean enabled, CallbackContext callbackContext) {

--- a/src/android/FirebaseCrashPlugin.java
+++ b/src/android/FirebaseCrashPlugin.java
@@ -2,17 +2,15 @@ package by.chemerisuk.cordova.firebase;
 
 import android.util.Log;
 
-import by.chemerisuk.cordova.support.CordovaMethod;
-import by.chemerisuk.cordova.support.ReflectiveCordovaPlugin;
-
 import com.google.firebase.crashlytics.FirebaseCrashlytics;
 
 import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
 import org.json.JSONArray;
 import org.json.JSONException;
 
 
-public class FirebaseCrashPlugin extends ReflectiveCordovaPlugin {
+public class FirebaseCrashPlugin extends CordovaPlugin {
     private final String TAG = "FirebaseCrashPlugin";
 
     private FirebaseCrashlytics firebaseCrashlytics;
@@ -25,45 +23,73 @@ public class FirebaseCrashPlugin extends ReflectiveCordovaPlugin {
             firebaseCrashlytics = FirebaseCrashlytics.getInstance();
         }
         catch (Exception e){
-            Log.e("Firebase Crashlytics Plugin", e.getMessage());
+            Log.e(TAG, "Unable to instantiate Crashlytics", e);
         }
     }
 
-    @CordovaMethod(ExecutionThread.WORKER)
-    private void forceCrash(CallbackContext callbackContext) {
-            new Thread(){
-                @Override
-                public void run() {
-                    throw new RuntimeException("MyCrash");
-                }
-            }.start();
+    @Override
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        switch (action) {
+            case "forceCrash":
+                forceCrash();
+                break;
+            case "log":
+                String message = args.optString(0);
+                log(message, callbackContext);
+                break;
+            case "logError":
+                String errorMessage = args.optString(0);
+                logError(errorMessage, callbackContext);
+                break;
+            case "setUserId":
+                String userId = args.optString(0);
+                setUserId(userId, callbackContext);
+                break;
+            case "setEnabled":
+                boolean isEnabled = args.getBoolean(0);
+                setEnabled(isEnabled, callbackContext);
+                break;
+            default:
+                return super.execute(action, args, callbackContext);
+        }
+        return true;
     }
 
-    @CordovaMethod(ExecutionThread.WORKER)
+    private void forceCrash() {
+        cordova.getThreadPool().execute(() -> {
+            throw new RuntimeException("MyCrash");
+        });
+    }
+
     private void log(String message, CallbackContext callbackContext) {
-        if(firebaseCrashlytics != null){
-            firebaseCrashlytics.log(message);
-            callbackContext.success();
-        }
+        cordova.getThreadPool().execute(() -> {
+            if(firebaseCrashlytics != null){
+                firebaseCrashlytics.log(message);
+                callbackContext.success();
+            }
+        });
     }
 
-    @CordovaMethod(ExecutionThread.UI)
     private void logError(String message, CallbackContext callbackContext) {
-        if(firebaseCrashlytics != null){
-            firebaseCrashlytics.recordException(new Exception(message));
-            callbackContext.success();
-        }
+        cordova.getActivity().runOnUiThread(() -> {
+            if(firebaseCrashlytics != null){
+                Exception error = new Exception(message);
+                Log.d(TAG, "Logging non-fatal error to crashlytics", error);
+                firebaseCrashlytics.recordException(error);
+                callbackContext.success();
+            }
+        });
     }
 
-    @CordovaMethod(ExecutionThread.UI)
     private void setUserId(String userId, CallbackContext callbackContext) {
-        if(firebaseCrashlytics != null){
-            firebaseCrashlytics.setUserId(userId);
-            callbackContext.success();
-        }
+        cordova.getActivity().runOnUiThread(() -> {
+            if(firebaseCrashlytics != null){
+                firebaseCrashlytics.setUserId(userId);
+                callbackContext.success();
+            }
+        });
     }
 
-    @CordovaMethod
     private void setEnabled(boolean enabled, CallbackContext callbackContext) {
         if(firebaseCrashlytics != null){
             firebaseCrashlytics.setCrashlyticsCollectionEnabled(enabled);

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -13,10 +13,13 @@ buildscript {
 
 def isApplication = plugins.hasPlugin("com.android.application")
 if (isApplication) {
-    // If this cordova plugin would be installed in a capacitor build, adding this code below would result in an error
-    //  Because capacitor installs plugins as library modules, and adding this block in the library module would result in an error
-    //  Cordova applies this gradle file to the app's build.gradle. To do the same in Capacitor, a build action needs to be used.
+    // If this cordova plugin would be installed in a capacitor build, adding this code below without hte if would result in an error.
+    //  Both Cordova and Capacitor apply this gradle file from the app's build.gradle
+    //  But because in Capacitor installs plugins as library modules, adding this block without the if would result in a build error:
+    //   "Applying the Firebase Crashlytics plugin to a library project is unsupported. (...)"
     apply plugin: com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPlugin
+
+    logger.error('Info: Additional insights.')
 
     android {
         buildTypes {

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 def isApplication = plugins.hasPlugin("com.android.application")
 if (isApplication) {
-    // If this cordova plugin would be installed in a capacitor build, adding this code below without hte if would result in an error.
+    // If this cordova plugin would be installed in a capacitor build, adding this code below without the if would result in an error.
     //  Both Cordova and Capacitor apply this gradle file from the app's build.gradle
     //  But because in Capacitor installs plugins as library modules, adding this block without the if would result in a build error:
     //   "Applying the Firebase Crashlytics plugin to a library project is unsupported. (...)"

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -11,14 +11,20 @@ buildscript {
     }
 }
 
-apply plugin: com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPlugin
+def isApplication = plugins.hasPlugin("com.android.application")
+if (isApplication) {
+    // If this cordova plugin would be installed in a capacitor build, adding this code below would result in an error
+    //  Because capacitor installs plugins as library modules, and adding this block in the library module would result in an error
+    //  Cordova applies this gradle file to the app's build.gradle. To do the same in Capacitor, a build action needs to be used.
+    apply plugin: com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsPlugin
 
-android {
-    buildTypes {
-        debug {
-            // do not upload debug versions to crashlytics
-            firebaseCrashlytics {
-                mappingFileUploadEnabled false
+    android {
+        buildTypes {
+            debug {
+                // do not upload debug versions to crashlytics
+                firebaseCrashlytics {
+                    mappingFileUploadEnabled false
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

Make the plugin compatible with Capacitor by making the following changes:

1. Remove dependencies on other cordova plugins. `cordova-outsystems-firebase-core` was unused, but `cordova-support-android-plugin` required changes on the Android bridge - plugin to inherit from `CordovaPlugin` instead of `ReflectiveCordovaPlugin`.
2. Change some `config-file` changes to `edit-config`.
3. Update `build.gradle` to only apply Crashlytics Android Gradle Plugin if it is in the scope of an application module - to avoid build error with a Capacitor build (that adds plugins as library modules).
4. Remaining changes in a build-actions file.

Note that Firebase Crashlytics pod uses `IOS_FIREBASE_CRASHLYTICS_VERSION`, and it still works in Capacitor build. It's just not configurable anymore, uses the default value. This wasn't exposed to Outsystems anyways, and since it's a high-code configuration, I'll argue that we don't need to support it.

## Context

References: https://outsystemsrd.atlassian.net/browse/RMET-3644

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests

Use builds of a new "TestFirebaseCrashlyticsApp" in ODC.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
