### PR TITLE
RMET-4310 - Update build action for MABS 12 to enable crashlytics for Android, not performance collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 3.0.0-OS13
+
+### 2025-07-08
+
+- Fix: Enable Crashlytics for Andorid instead of Performance Collection (https://outsystemsrd.atlassian.net/browse/RMET-4310).
+
 ## 3.0.0-OS12
 
 ### 2025-05-05

--- a/build-actions/updateCrashlyticsConfig.yaml
+++ b/build-actions/updateCrashlyticsConfig.yaml
@@ -9,7 +9,7 @@ platforms:
       - file: AndroidManifest.xml
         target: manifest/application
         inject: |
-          <meta-data android:name="firebase_performance_collection_enabled" android:value="$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" />
+          <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" />
   ios:
     plist:
       - replace: false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-crash",
-  "version": "3.0.0-OS12",
+  "version": "3.0.0-OS13",
   "description": "Cordova plugin for Firebase Crashlytics",
   "cordova": {
     "id": "cordova-plugin-firebase-crash",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-crash"
-      version="3.0.0-OS12">
+      version="3.0.0-OS13">
 
     <name>cordova-plugin-firebase-crash</name>
     <description>Cordova plugin for Firebase Crashlytics</description>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Fixes build action, enabling crashlytics instead of performance collection for Android and MABS 12.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4310

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
