### PR TITLE
chore(android,ios): remove unnecessary Firebase preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 3.0.0-OS15
+
+### 2026-01-20
+
+- Chore: remove unnecessary Firebase preferences on Android and iOS (https://outsystemsrd.atlassian.net/browse/RMET-4915).
+
 ## 3.0.0-OS14
 
 ### 2026-01-07

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -25,7 +25,6 @@
 
 ## Checklist
 <!--- Go over all the following items and put an `x` in all the boxes that apply -->
-- [ ] Pull request title follows the format `RNMT-XXXX <title>`
 - [ ] Code follows code style of this project
 - [ ] CHANGELOG.md file is correctly updated
 - [ ] Changes require an update to the documentation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-crash",
-  "version": "3.0.0-OS14",
+  "version": "3.0.0-OS15",
   "description": "Cordova plugin for Firebase Crashlytics",
   "cordova": {
     "id": "cordova-plugin-firebase-crash",

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,8 +20,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <merges target="cordova.plugins.firebase.crashlytics" />
     </js-module>
 
-    <preference name="FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" default="true" />
-
     <platform name="ios">
         <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="10.23.0"/>
 
@@ -39,9 +37,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             use a bit hacky method to set boolean value as a string:
             https://developer.apple.com/documentation/foundation/nsstring/1409420-boolvalue?preferredLanguage=occ
         -->
-        <config-file target="*-Info.plist" parent="FirebaseCrashlyticsCollectionEnabled">
-            <string>$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED</string>
-        </config-file>
 
         <header-file src="src/ios/FirebaseCrashPlugin.h" />
         <source-file src="src/ios/FirebaseCrashPlugin.m" />
@@ -71,10 +66,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <edit-config target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.INTERNET" />
   		</edit-config>
-
-        <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" />
-        </config-file>
 
         <source-file src="src/android/FirebaseCrashPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase/" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -68,10 +68,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
   		</edit-config>
 
         <source-file src="src/android/FirebaseCrashPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase/" />
-
-        <dependency id="cordova-support-android-plugin" version=">=1.0.0"/>
-        <framework src="com.google.firebase:firebase-crashlytics:$ANDROID_FIREBASE_CRASHLYTICS_VERSION" />
         <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     </platform>
-
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-crash"
-      version="3.0.0-OS14">
+      version="3.0.0-OS15">
 
     <name>cordova-plugin-firebase-crash</name>
     <description>Cordova plugin for Firebase Crashlytics</description>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR removes the following Firebase preferences:
    - `firebase_crashlytics_collection_enabled` on Android
    - `FirebaseCrashlyticsCollectionEnabled` on iOS

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
- We were always setting these to `true`, which is unnecessary, because they're already `true` by default.
- Also, on iOS, we were setting it as a `string` in the `.plist` file instead of a `boolean`, which was wrong. It probably didn't have an effect because it was already `true` by default.

References: https://outsystemsrd.atlassian.net/browse/RMET-4915

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested in O11 and ODC with our Firebase Sample App.

MABS builds:

- [Android](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=4e512ce67b64e4b979fec17ed594d323390b7315&stg=dev)
- [iOS](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=16264775c84f56d2cc618fc200897b3115804959&stg=dev)

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
