### PR TITLE
fix(android,ios): properly set FirebaseCrashlyticsCollectionEnabled for Cordova apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 3.0.0-OS16
+
+### 2026-02-05
+
+- Fix: properly set FirebaseCrashlyticsCollectionEnabled for Cordova apps (https://outsystemsrd.atlassian.net/browse/RMET-4850)
+
 ## 3.0.0-OS15
 
 ### 2026-01-20

--- a/hooks/android/androidCopyPreferences.js
+++ b/hooks/android/androidCopyPreferences.js
@@ -1,0 +1,61 @@
+const path = require('path');
+const fs = require('fs');
+const { ConfigParser } = require('cordova-common');
+const xml2js = require('xml2js');
+const q = require('q');
+
+module.exports = function (context) {
+    let projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+    let configXML = path.join(projectRoot, 'config.xml');
+    let configParser = new ConfigParser(configXML);
+    
+    let manifestPath = path.join(projectRoot, 'platforms/android/app/src/main/AndroidManifest.xml');
+
+    let defer = q.defer();
+
+    let collectionEnabled = configParser.getGlobalPreference("FIREBASE_CRASHLYTICS_COLLECTION_ENABLED");    
+    if (collectionEnabled.toLowerCase() == 'false') {
+        let parser = new xml2js.Parser();
+        parser.parseStringPromise(fs.readFileSync(manifestPath, 'utf8')).then((result) => {
+            const appNode = result.manifest.application[0];
+            appNode['meta-data'] = appNode['meta-data'] || [];
+            const metadata = appNode['meta-data'];
+
+            let updated = false;
+
+            // find existing entry index
+            const index = metadata.findIndex(item => 
+                item['$']?.['android:name'] === 'firebase_crashlytics_collection_enabled'
+            );
+
+            if (index !== -1) {
+                // entry exists, check if we should update it
+                if (metadata[index]['$']['android:value'] === 'true') {
+                    metadata[index]['$']['android:value'] = 'false';
+                    updated = true;
+                }
+            } else {
+                // entry doesn't exist, add it
+                metadata.push({
+                    '$': {
+                        'android:name': 'firebase_crashlytics_collection_enabled',
+                        'android:value': 'false'
+                     }
+                });
+                updated = true;
+            }
+            if (updated) {
+                const builder = new xml2js.Builder();
+                const xml = builder.buildObject(result);
+                fs.writeFileSync(manifestPath, xml);
+            }
+            defer.resolve();
+        })
+        .catch((err) => {
+            throw new Error (`OUTSYSTEMS_PLUGIN_ERROR: Something went wrong while parsing the AndroidManifest.xml file. Please check the logs for more information.`);
+        });
+    } else {
+        defer.resolve();
+    }
+    return defer.promise;
+};

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -1,0 +1,21 @@
+const path = require('path');
+const fs = require('fs');
+const plist = require('plist');
+const { ConfigParser } = require('cordova-common');
+
+module.exports = function (context) {
+    let projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
+    let configXML = path.join(projectRoot, 'config.xml');
+    let configParser = new ConfigParser(configXML);
+    
+    let appName = configParser.name();
+    let infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
+    let obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
+
+    let collectionEnabled = configParser.getGlobalPreference("FIREBASE_CRASHLYTICS_COLLECTION_ENABLED");
+    if (collectionEnabled.toLowerCase() == 'false') {
+        obj['FirebaseCrashlyticsCollectionEnabled'] = false;
+    }
+
+    fs.writeFileSync(infoPlistPath, plist.build(obj));
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-crash",
-  "version": "3.0.0-OS15",
+  "version": "3.0.0-OS16",
   "description": "Cordova plugin for Firebase Crashlytics",
   "cordova": {
     "id": "cordova-plugin-firebase-crash",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-crash"
-      version="3.0.0-OS15">
+      version="3.0.0-OS16">
 
     <name>cordova-plugin-firebase-crash</name>
     <description>Cordova plugin for Firebase Crashlytics</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -73,6 +73,10 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <uses-permission android:name="android.permission.INTERNET" />
   		</edit-config>
 
+        <config-file target="AndroidManifest.xml" parent="/manifest/application">
+            <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" />
+        </config-file>
+
         <source-file src="src/android/FirebaseCrashPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase/" />
         <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -73,10 +73,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             <uses-permission android:name="android.permission.INTERNET" />
   		</edit-config>
 
-        <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <meta-data android:name="firebase_crashlytics_collection_enabled" android:value="$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" />
-        </config-file>
-
         <source-file src="src/android/FirebaseCrashPlugin.java" target-dir="src/by/chemerisuk/cordova/firebase/" />
         <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,6 +25,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <hook type="after_plugin_install" src="hooks/ios/after_plugin_install.js" />
         <hook type="before_plugin_uninstall" src="hooks/ios/before_plugin_uninstall.js" />
+        <hook type="after_prepare" src="hooks/ios/iOSCopyPreferences.js" />
 
         <config-file parent="/*" target="config.xml">
             <feature name="FirebaseCrash">
@@ -55,6 +56,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     <platform name="android">
 
         <hook type="before_plugin_install" src="hooks/android/build_gradle_add_dependency.js" />
+        <hook type="after_prepare" src="hooks/android/androidCopyPreferences.js" />
         
         <config-file parent="/*" target="res/xml/config.xml">
             <feature name="FirebaseCrash">

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,6 +20,8 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <merges target="cordova.plugins.firebase.crashlytics" />
     </js-module>
 
+    <preference name="FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" default="true" />
+
     <platform name="ios">
         <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="10.23.0"/>
 
@@ -37,6 +39,10 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             use a bit hacky method to set boolean value as a string:
             https://developer.apple.com/documentation/foundation/nsstring/1409420-boolvalue?preferredLanguage=occ
         -->
+
+        <config-file target="*-Info.plist" parent="FirebaseCrashlyticsCollectionEnabled">
+            <string>$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED</string>
+        </config-file>
 
         <header-file src="src/ios/FirebaseCrashPlugin.h" />
         <source-file src="src/ios/FirebaseCrashPlugin.m" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,8 +20,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <merges target="cordova.plugins.firebase.crashlytics" />
     </js-module>
 
-    <preference name="FIREBASE_CRASHLYTICS_COLLECTION_ENABLED" default="true" />
-
     <platform name="ios">
         <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="10.23.0"/>
 
@@ -39,10 +37,6 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             use a bit hacky method to set boolean value as a string:
             https://developer.apple.com/documentation/foundation/nsstring/1409420-boolvalue?preferredLanguage=occ
         -->
-
-        <config-file target="*-Info.plist" parent="FirebaseCrashlyticsCollectionEnabled">
-            <string>$FIREBASE_CRASHLYTICS_COLLECTION_ENABLED</string>
-        </config-file>
 
         <header-file src="src/ios/FirebaseCrashPlugin.h" />
         <source-file src="src/ios/FirebaseCrashPlugin.m" />


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Properly sets `FirebaseCrashlyticsCollectionEnabled` to false for Cordova apps when the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` preference is false.
- No need to set it to true since it is already true by default for both Android and iOS.
- Note: hook code took and adapted from https://github.com/OutSystems/cordova-plugin-firebase-analytics

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4850

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested with MABS 11.2 and 12 builds on our tenant.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
