### PR TITLE
feat(ios): Support Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ jspm_packages
 .node_repl_history
 
 .DS_Store
+
+# Swift Package Manager
+Package.resolved
+.build/
+.swiftpm/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The changes documented here do not include those from the original repository.
 
 ### 2026-04-28
 
-- Feat: iOS | Support Swift Package Manager (https://outsystemsrd.atlassian.net/browse/RMET-5139)
+- Feat: iOS | Support Swift Package Manager and Cordova iOS 8 (https://outsystemsrd.atlassian.net/browse/RMET-5139)
 
 ## 3.0.0-OS16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 3.0.0-OS17
+
+### 2026-04-28
+
+- Feat: iOS | Support Swift Package Manager (https://outsystemsrd.atlassian.net/browse/RMET-5139)
+
 ## 3.0.0-OS16
 
 ### 2026-02-05

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "cordova-plugin-firebase-crash",
+    platforms: [.iOS(.v15)],
+    products: [
+        .library(
+            name: "cordova-plugin-firebase-crash",
+            targets: ["cordova-plugin-firebase-crash"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "10.29.0")
+    ],
+    targets: [
+        .target(
+            name: "cordova-plugin-firebase-crash",
+            dependencies: [
+                .product(name: "Cordova", package: "cordova-ios"),
+                .product(name: "FirebaseCrashlytics", package: "firebase-ios-sdk")
+            ],
+            path: "src/ios",
+            publicHeadersPath: ".")
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apache/cordova-ios.git", branch: "master"),
-        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", exact: "10.29.0")
+        .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "10.29.0")
     ],
     targets: [
         .target(

--- a/build-actions/README.md
+++ b/build-actions/README.md
@@ -5,12 +5,12 @@ This folder contains a .yaml file for configuring build actions to use in a plug
 
 ## Contents
 
-The file [updateCrashlyticsConfig.yaml](./updateCrashlyticsConfig.yaml) contains three build actions:
+The file [updateCrashlyticsConfig.yaml](./updateCrashlyticsConfig.yaml) contains two build actions:
 
 1. Android specific. Adds the `firebase_performance_collection_enabled` meta-data entry - according to the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` parameter - to the app's `AndroidManifest.xml`. With it you can enable/disable crashlytics in the Android app.
 2. iOS specific. Set `FirebaseCrashlyticsCollectionEnabled` - according to the `FIREBASE_CRASHLYTICS_COLLECTION_ENABLED` parameter - in the app's Info.plist file. With it you can enable/disable crashlytics in the iOS app.
-3. iOS specific. Adds a build phase for XCode to upload files to Firebase, to help with getting more readable crash reports.
 
+Note: Some specific changes cannot be done via Build Actions. Refer to [capacitor hooks folder](../hooks/capacitor/) for more information.
 
 ## Outsystems' Usage
 

--- a/build-actions/updateCrashlyticsConfig.yaml
+++ b/build-actions/updateCrashlyticsConfig.yaml
@@ -15,10 +15,3 @@ platforms:
       - replace: false
         entries:
           - FirebaseCrashlyticsCollectionEnabled: $FIREBASE_CRASHLYTICS_COLLECTION_ENABLED
-    buildPhases:
-      - comment: Crashlytics
-        shellPath: "/bin/sh"
-        shellScript: "\"${PODS_ROOT}/FirebaseCrashlytics/run\""
-        inputPaths: ["\"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)\""]
-    
-  

--- a/hooks/capacitor/after_cap_sync.js
+++ b/hooks/capacitor/after_cap_sync.js
@@ -35,9 +35,16 @@ async function main() {
     const buildPhase = xcodeProject.pbxItemByComment(BUILD_PHASE_COMMENT, 'PBXShellScriptBuildPhase');
 
     if (!buildPhase) {
+        let shellScriptLocation = '"${PODS_ROOT}/FirebaseCrashlytics/run"';
+        const capSPMPath = path.join(iosDir, 'App', 'CapApp-SPM');
+        if (fs.existsSync(capSPMPath)) {
+            // SPM apps have the firebase iOS SDK in a different location
+            shellScriptLocation = '"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"';
+        }
+
         const result = xcodeProject.addBuildPhase([], 'PBXShellScriptBuildPhase', BUILD_PHASE_COMMENT, null, {
             shellPath: '/bin/sh',
-            shellScript: '"${PODS_ROOT}/FirebaseCrashlytics/run"',
+            shellScript: shellScriptLocation,
             inputPaths: ['"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)"'],
         });
 

--- a/hooks/capacitor/after_cap_sync.js
+++ b/hooks/capacitor/after_cap_sync.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * Capacitor hook included with the plugin: runs after npx cap sync
+ *
+ * Adds the Crashlytics build phase to the Xcode project after `npx cap sync`,
+ * mirroring what the Cordova `after_plugin_install` hook does for Cordova shells.
+ * 
+ * The hook will write a different path depending on the app being CocoaPods or SPM.
+ *
+ * Capacitor CLI sets CAPACITOR_PLATFORM_NAME to the platform being synced
+ * and CAPACITOR_ROOT_DIR to the app's root directory.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const xcode = require('../ios/xcode');
+
+const BUILD_PHASE_COMMENT = 'Crashlytics';
+
+async function main() {
+    const platform = process.env.CAPACITOR_PLATFORM_NAME;
+
+    if (platform && platform !== 'ios') {
+        return;
+    }
+
+    const iosDir = path.resolve(process.env.CAPACITOR_ROOT_DIR, 'ios');
+    const xcodeProjectPath = path.join(iosDir, 'App', 'App.xcodeproj', 'project.pbxproj');
+
+    const xcodeProject = xcode.project(xcodeProjectPath);
+    xcodeProject.parseSync();
+
+    // Only add if not already there yet
+    const buildPhase = xcodeProject.pbxItemByComment(BUILD_PHASE_COMMENT, 'PBXShellScriptBuildPhase');
+
+    if (!buildPhase) {
+        const result = xcodeProject.addBuildPhase([], 'PBXShellScriptBuildPhase', BUILD_PHASE_COMMENT, null, {
+            shellPath: '/bin/sh',
+            shellScript: '"${PODS_ROOT}/FirebaseCrashlytics/run"',
+            inputPaths: ['"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)"'],
+        });
+
+        result.buildPhase.runOnlyForDeploymentPostprocessing = 1;
+
+        fs.writeFileSync(xcodeProjectPath, xcodeProject.writeSync());
+
+        console.log('\t[cordova-plugin-firebase-crash] [SUCCESS] Crashlytics build phase added to Xcode project.');
+    } else {
+        console.log('\t[cordova-plugin-firebase-crash] [SKIP] Crashlytics build phase already exists in Xcode project.');
+    }
+}
+
+main().catch(function (err) {
+    console.error('\t[cordova-plugin-firebase-crash] [ERROR] capacitor:sync:after hook failed:', err);
+    process.exit(1);
+});

--- a/hooks/ios/after_plugin_install.js
+++ b/hooks/ios/after_plugin_install.js
@@ -14,9 +14,7 @@ module.exports = function(context) {
     const buildPhase = xcodeProject.pbxItemByComment(comment, "PBXShellScriptBuildPhase");
 
     if (!buildPhase) {
-        const cordovaIosVersion = context.requireCordovaModule("cordova-ios/package").version;
-        const cordovaIosMajor = parseInt(cordovaIosVersion.split(".")[0], 10);
-        const supportsSPM = cordovaIosMajor >= 8;
+        const supportsSPM = helper.isCordovaIos8OrHigher();
 
         const shellScript = supportsSPM
             ? "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\""

--- a/hooks/ios/after_plugin_install.js
+++ b/hooks/ios/after_plugin_install.js
@@ -14,9 +14,17 @@ module.exports = function(context) {
     const buildPhase = xcodeProject.pbxItemByComment(comment, "PBXShellScriptBuildPhase");
 
     if (!buildPhase) {
+        const cordovaIosVersion = context.requireCordovaModule("cordova-ios/package").version;
+        const cordovaIosMajor = parseInt(cordovaIosVersion.split(".")[0], 10);
+        const supportsSPM = cordovaIosMajor >= 8;
+
+        const shellScript = supportsSPM
+            ? "\"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\""
+            : "\"${PODS_ROOT}/FirebaseCrashlytics/run\"";
+
         const result = xcodeProject.addBuildPhase([], "PBXShellScriptBuildPhase", comment, null, {
             shellPath: "/bin/sh",
-            shellScript: "\"${PODS_ROOT}/FirebaseCrashlytics/run\"",
+            shellScript: shellScript,
             inputPaths: ["\"$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)\""]
         });
 

--- a/hooks/ios/helper.js
+++ b/hooks/ios/helper.js
@@ -4,6 +4,15 @@ const fs = require("fs");
 module.exports = {
     BUILD_PHASE_COMMENT: "Crashlytics",
 
+    isCordovaIos8OrHigher: function() {
+        const iosPackageJsonPath = path.join("platforms", "ios", "package.json");
+        if (!fs.existsSync(iosPackageJsonPath)) {
+            return false;
+        }
+        const iosPackage = JSON.parse(fs.readFileSync(iosPackageJsonPath, "utf8"));
+        return parseInt(iosPackage.version.split(".")[0], 10) >= 8;
+    },
+
     getXcodeProjectPath: function(context) {
         // cordova-ios 8+ uses 'App.xcodeproj' as the fixed project name
         // cordova-ios <8 uses the app name as the project name

--- a/hooks/ios/helper.js
+++ b/hooks/ios/helper.js
@@ -5,12 +5,12 @@ module.exports = {
     BUILD_PHASE_COMMENT: "Crashlytics",
 
     isCordovaIos8OrHigher: function() {
-        const iosPackageJsonPath = path.join("platforms", "ios", "package.json");
-        if (!fs.existsSync(iosPackageJsonPath)) {
+        const apiPath = path.resolve("platforms", "ios", "cordova", "Api.js");
+        if (!fs.existsSync(apiPath)) {
             return false;
         }
-        const iosPackage = JSON.parse(fs.readFileSync(iosPackageJsonPath, "utf8"));
-        return parseInt(iosPackage.version.split(".")[0], 10) >= 8;
+        const version = require(apiPath).version();
+        return parseInt(version.split(".")[0], 10) >= 8;
     },
 
     getXcodeProjectPath: function(context) {

--- a/hooks/ios/helper.js
+++ b/hooks/ios/helper.js
@@ -1,9 +1,16 @@
 const path = require("path");
+const fs = require("fs");
 
 module.exports = {
     BUILD_PHASE_COMMENT: "Crashlytics",
 
     getXcodeProjectPath: function(context) {
+        // cordova-ios 8+ uses 'App.xcodeproj' as the fixed project name
+        // cordova-ios <8 uses the app name as the project name
+        const cordovaIos8Path = path.join("platforms", "ios", "App.xcodeproj", "project.pbxproj");
+        if (fs.existsSync(cordovaIos8Path)) {
+            return cordovaIos8Path;
+        }
         const ConfigParser = context.requireCordovaModule("cordova-lib").configparser;
         const appName = new ConfigParser("config.xml").name();
         return path.join("platforms", "ios", appName + ".xcodeproj", "project.pbxproj");

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -7,15 +7,21 @@ module.exports = function (context) {
     let projectRoot = context.opts.cordova.project ? context.opts.cordova.project.root : context.opts.projectRoot;
     let configXML = path.join(projectRoot, 'config.xml');
     let configParser = new ConfigParser(configXML);
-    
-    let appName = configParser.name();
-    let infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/'+ appName +'-info.plist');
-    let obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
 
     let collectionEnabled = configParser.getGlobalPreference("FIREBASE_CRASHLYTICS_COLLECTION_ENABLED");
-    if (collectionEnabled.toLowerCase() == 'false') {
-        obj['FirebaseCrashlyticsCollectionEnabled'] = false;
+    if (!collectionEnabled || collectionEnabled.toLowerCase() !== 'false') {
+        return;
     }
 
+    // cordova-ios 8+ uses 'App' as the fixed project folder name and 'App-Info.plist'
+    // cordova-ios <8 uses the app name as the project folder name
+    let infoPlistPath = path.join(projectRoot, 'platforms/ios/App/App-Info.plist');
+    if (!fs.existsSync(infoPlistPath)) {
+        let appName = configParser.name();
+        infoPlistPath = path.join(projectRoot, 'platforms/ios/' + appName + '/' + appName + '-info.plist');
+    }
+
+    let obj = plist.parse(fs.readFileSync(infoPlistPath, 'utf8'));
+    obj['FirebaseCrashlyticsCollectionEnabled'] = false;
     fs.writeFileSync(infoPlistPath, plist.build(obj));
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-crash",
-  "version": "3.0.0-OS16",
+  "version": "3.0.0-OS17",
   "description": "Cordova plugin for Firebase Crashlytics",
   "cordova": {
     "id": "cordova-plugin-firebase-crash",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   ],
   "scripts": {
     "version": "replace -s 'version=\"(.+)(?=\">)' 'version=\"'$npm_package_version plugin.xml && git add plugin.xml",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
+    "capacitor:sync:after": "node hooks/capacitor/after_cap_sync.js"
   },
   "dependencies": {
   }

--- a/plugin.xml
+++ b/plugin.xml
@@ -20,7 +20,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         <merges target="cordova.plugins.firebase.crashlytics" />
     </js-module>
 
-    <platform name="ios">
+    <platform name="ios" package="swift">
         <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="10.29.0"/>
 
         <hook type="after_plugin_install" src="hooks/ios/after_plugin_install.js" />
@@ -47,7 +47,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="FirebaseCrashlytics" spec="$IOS_FIREBASE_CRASHLYTICS_VERSION" />
+                <pod name="FirebaseCrashlytics" spec="$IOS_FIREBASE_CRASHLYTICS_VERSION"  nospm="true" />
             </pods>
         </podspec>
         

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-crash"
-      version="3.0.0-OS16">
+      version="3.0.0-OS17">
 
     <name>cordova-plugin-firebase-crash</name>
     <description>Cordova plugin for Firebase Crashlytics</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
     </js-module>
 
     <platform name="ios">
-        <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="10.23.0"/>
+        <preference name="IOS_FIREBASE_CRASHLYTICS_VERSION" default="10.29.0"/>
 
         <hook type="after_plugin_install" src="hooks/ios/after_plugin_install.js" />
         <hook type="before_plugin_uninstall" src="hooks/ios/before_plugin_uninstall.js" />


### PR DESCRIPTION
# ⚠️🤖  AI-Assisted development with Claude Code 🤖⚠️

## Description

This PR adds support for Swift Package Manager, by adding a `Package.swift` file to the plugin, and also updating the `plugin.xml` to not use the Firebase SDK Pod for an app that uses SPM dependencies. The Firebase SDK dependency was updated to 10.29.0 to sync with other Firebase Plugins.

Furthermore, this PR updates the hooks (Cordova and Capacitor, the latter previously being a build action) to correctly the `pbxproj` build phase script depending on if the app is using CocoaPods or SPM. For Cordova, had to check if the app was using Cordova iOS 8 or not by checking Cordova iOS version using an `Api.js` file available in the Cordova iOS 8 app. It could be that when we reach MABS 13, if the Cordova iOS fork differs a lot from the upstream, that this check won't work, but for now it supports Cordova iOS 8; I had tried other options like checking package.json's or trying to check installed pods / swift packages, but was unsuccessful, so this was the better option I found.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-5139

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests

You can use a few different test apps to test that everything's still working with Crashlytics. They contain a button to log errors (non-fatal error), and to force a crash. The bundle ID is `com.outsystems.rd.FirebaseAnalyticsSampleApp`, and you can check if crashes reach the [Firebase Console here](https://console.firebase.google.com/u/0/project/mobileecosystem-b80d4/crashlytics/app/ios:com.outsystems.rd.FirebaseAnalyticsSampleApp/issues?time=60m&state=all&tag=all&sort=eventCount). Crashes may take anywhere from a few seconds to a couple minutes to show up. 

The version number of the apps below are not in order, so if you're going to test multiple apps in the same device, you may need to uninstall some to install the next.

- [Regular Capacitor app with SPM](https://drive.google.com/file/d/1qyFsEm1FmGYH-egy2zABTksjaLsykqj5/view?usp=sharing); Source code[available here](https://github.com/ionic-team/cordova-plugins-ios-spm-test-apps/tree/main/firebase-crashlytics-capacitor-spm)
- [OutSystems ODC App](https://eng-test-us-01.outsystems.dev/apps/application?id=998b97c1-57fd-4061-9511-70940ad0fa41&mobileoption=ios&stageid=ee84a6d3-b083-46fd-9118-358498476969&tab=mobiledistribution)
     - [MABS 12.1 Capacitor SPM](https://drive.google.com/file/d/18k0k1P-w3vL3p6QyA78hInXDCfA2YrR7/view?usp=sharing) (requires Capacitor CLI version that is unreleased); Source code [zip file](https://drive.google.com/file/d/1oMlPETBu1BiIuVCRVLX3dXguP22_ppeK/view?usp=sharing)
     - [MABS 12.0 Capacitor CocoaPods](https://drive.google.com/file/d/1_qbEo_VSx96lBM6oQBs0q9D_ginvOGB1/view?usp=sharing)
     - [MABS 12.0 Cordova](https://drive.google.com/file/d/10kL3bjz_DSKXKf5fTZVJAFrNBGEhjm7M/view?usp=sharing)
     - [MABS 11.2 Cordova](https://drive.google.com/file/d/1pTzG3QMuiPE0rlQLl6NEELfJTR0BMTI5/view?usp=sharing)
- [Cordova iOS 8 app](https://drive.google.com/file/d/1J4tSUiMvk3PUBqBmYzl-Dc86K4YeFP0E/view?usp=sharing); Source code [available here](https://github.com/ionic-team/cordova-plugins-ios-spm-test-apps/tree/main/firebase-crashlytics-cordova-ios8)
